### PR TITLE
prioritize payload coversion_id over settings conversion_id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,17 @@ import { ComponentSettings, Manager, MCEvent } from '@managed-components/types'
 
 export const sendEvent =
   (id: string) =>
-  ({ client }: MCEvent) => {
-    client.fetch(`https://conv.indeed.com/pagead/conv/${id}/?script=0`, {
-      credentials: 'include',
-      keepalive: true,
-      mode: 'no-cors',
-    })
+  ({ client, payload }: MCEvent) => {
+    client.fetch(
+      `https://conv.indeed.com/pagead/conv/${
+        payload.conversion_id || id
+      }/?script=0`,
+      {
+        credentials: 'include',
+        keepalive: true,
+        mode: 'no-cors',
+      }
+    )
   }
 
 export default async function (manager: Manager, settings: ComponentSettings) {


### PR DESCRIPTION
Since the tool template allows to have `conversion_id` field in both actions and settings, we should check for both and prioritize the one from action